### PR TITLE
Additional types for the AvatarSearchQuery struct

### DIFF
--- a/examples/avatar_catalog_search.rs
+++ b/examples/avatar_catalog_search.rs
@@ -1,10 +1,13 @@
-use roboat::catalog::{AvatarSearchQueryBuilder, Category};
+use roboat::catalog::{AvatarSearchQueryBuilder, CatalogQueryLimit, Category, SalesTypeFilter};
 use roboat::{ClientBuilder, RoboatError};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let query = AvatarSearchQueryBuilder::new()
         .keyword("cute".to_owned())
+        .min_price(300)
+        .sales_type_filter(SalesTypeFilter::Collectibles)
+        .limit(CatalogQueryLimit::TwentyEight)
         .category(Category::Accessories)
         .build();
 

--- a/src/catalog/catalog_types.rs
+++ b/src/catalog/catalog_types.rs
@@ -700,9 +700,9 @@ pub struct AvatarSearchQuery {
     /// Subcategory must be filled to query more than one page.
     pub subcategory: Option<Subcategory>,
     /// The minimum price for each asset.
-    pub min_price: Option<u32>,
+    pub min_price: Option<u64>,
     /// The maximum price for each asset.
-    pub max_price: Option<u32>,
+    pub max_price: Option<u64>,
     /// The maximum assets Roblox should return per page.
     /// View [`Limit`] for more information.
     pub limit: Option<Limit>,
@@ -855,13 +855,13 @@ impl AvatarSearchQueryBuilder {
     }
 
     #[allow(missing_docs)]
-    pub fn min_price(mut self, min_price: u32) -> Self {
+    pub fn min_price(mut self, min_price: u64) -> Self {
         self.query.min_price = Some(min_price);
         self
     }
 
     #[allow(missing_docs)]
-    pub fn max_price(mut self, max_price: u32) -> Self {
+    pub fn max_price(mut self, max_price: u64) -> Self {
         self.query.max_price = Some(max_price);
         self
     }

--- a/src/catalog/catalog_types.rs
+++ b/src/catalog/catalog_types.rs
@@ -225,6 +225,60 @@ impl SortType {
     }
 }
 
+/// Sort between different sale types of assets, used when searching.
+/// Values can be from here <https://create.roblox.com/docs/reference/engine/enums/SalesTypeFilter>.
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Serialize, Deserialize, Copy,
+)]
+#[allow(missing_docs)]
+pub enum SalesTypeFilter {
+    #[default]
+    All,
+    Collectibles,
+    Premium,
+}
+
+impl SalesTypeFilter {
+    pub(crate) fn as_u8(&self) -> u8 {
+        match self {
+            Self::All => 1,
+            Self::Collectibles => 2,
+            Self::Premium => 3,
+        }
+    }
+}
+
+/// Limit the amount of results shown by the API when searching.
+/// Values can be found when entering an invalid limit to the API <https://catalog.roblox.com/v1/search/items?limit=110>.
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Serialize, Deserialize, Copy,
+)]
+#[allow(missing_docs)]
+pub enum Limit {
+    #[default]
+    Ten,
+    TwentyEight,
+    Thirty,
+    Fifty,
+    Sixty,
+    Hundred,
+    HundredTwenty,
+}
+
+impl Limit {
+    pub(crate) fn as_u8(&self) -> u8 {
+        match self {
+            Limit::Ten => 10,
+            Limit::TwentyEight => 28,
+            Limit::Thirty => 30,
+            Limit::Fifty => 50,
+            Limit::Sixty => 60,
+            Limit::Hundred => 100,
+            Limit::HundredTwenty => 120,
+        }
+    }
+}
+
 /// A subcategory for items, used when searching.
 #[allow(missing_docs)]
 #[derive(
@@ -645,6 +699,16 @@ pub struct AvatarSearchQuery {
     pub sort_type: Option<SortType>,
     /// Subcategory must be filled to query more than one page.
     pub subcategory: Option<Subcategory>,
+    /// The minimum price for each asset.
+    pub min_price: Option<u32>,
+    /// The maximum price for each asset.
+    pub max_price: Option<u32>,
+    /// The maximum assets Roblox should return per page.
+    /// View [`Limit`] for more information.
+    pub limit: Option<Limit>,
+    /// Sort between different sale types of assets.
+    /// View [`SalesTypeFilter`] for more information.
+    pub sales_type_filter: Option<SalesTypeFilter>,
 }
 
 impl AvatarSearchQuery {
@@ -690,6 +754,22 @@ impl AvatarSearchQuery {
 
         if let Some(subcategory) = self.subcategory {
             url.push_str(&format!("subcategory={}&", subcategory.as_u8()));
+        }
+
+        if let Some(min_price) = self.min_price {
+            url.push_str(&format!("minPrice={}&", min_price));
+        }
+
+        if let Some(max_price) = self.max_price {
+            url.push_str(&format!("maxPrice={}&", max_price));
+        }
+
+        if let Some(limit) = self.limit {
+            url.push_str(&format!("limit={}&", limit.as_u8()));
+        }
+
+        if let Some(sales_type_filter) = self.sales_type_filter {
+            url.push_str(&format!("salesTypeFilter={}&", sales_type_filter.as_u8()));
         }
 
         // Remove the last & if it exists.
@@ -771,6 +851,30 @@ impl AvatarSearchQueryBuilder {
     #[allow(missing_docs)]
     pub fn subcategory(mut self, subcategory: Subcategory) -> Self {
         self.query.subcategory = Some(subcategory);
+        self
+    }
+
+    #[allow(missing_docs)]
+    pub fn min_price(mut self, min_price: u32) -> Self {
+        self.query.min_price = Some(min_price);
+        self
+    }
+
+    #[allow(missing_docs)]
+    pub fn max_price(mut self, max_price: u32) -> Self {
+        self.query.max_price = Some(max_price);
+        self
+    }
+
+    #[allow(missing_docs)]
+    pub fn limit(mut self, limit: Limit) -> Self {
+        self.query.limit = Some(limit);
+        self
+    }
+
+    #[allow(missing_docs)]
+    pub fn sales_type_filter(mut self, sales_type_filter: SalesTypeFilter) -> Self {
+        self.query.sales_type_filter = Some(sales_type_filter);
         self
     }
 }

--- a/src/catalog/catalog_types.rs
+++ b/src/catalog/catalog_types.rs
@@ -259,13 +259,13 @@ impl SalesTypeFilter {
 )]
 #[allow(missing_docs)]
 pub enum CatalogQueryLimit {
-    #[default]
     Ten,
     TwentyEight,
     Thirty,
     Fifty,
     Sixty,
     Hundred,
+    #[default]
     HundredTwenty,
 }
 

--- a/src/catalog/catalog_types.rs
+++ b/src/catalog/catalog_types.rs
@@ -250,11 +250,13 @@ impl SalesTypeFilter {
 
 /// Limit the amount of results shown by the API when searching.
 /// Values can be found when entering an invalid limit to the API <https://catalog.roblox.com/v1/search/items?limit=110>.
+///
+/// This is a special Roblox limit that does not match the universal [`Limit`].
 #[derive(
     Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Serialize, Deserialize, Copy,
 )]
 #[allow(missing_docs)]
-pub enum Limit {
+pub enum CatalogQueryLimit {
     #[default]
     Ten,
     TwentyEight,
@@ -265,16 +267,16 @@ pub enum Limit {
     HundredTwenty,
 }
 
-impl Limit {
+impl CatalogQueryLimit {
     pub(crate) fn as_u8(&self) -> u8 {
         match self {
-            Limit::Ten => 10,
-            Limit::TwentyEight => 28,
-            Limit::Thirty => 30,
-            Limit::Fifty => 50,
-            Limit::Sixty => 60,
-            Limit::Hundred => 100,
-            Limit::HundredTwenty => 120,
+            Self::Ten => 10,
+            Self::TwentyEight => 28,
+            Self::Thirty => 30,
+            Self::Fifty => 50,
+            Self::Sixty => 60,
+            Self::Hundred => 100,
+            Self::HundredTwenty => 120,
         }
     }
 }
@@ -704,8 +706,8 @@ pub struct AvatarSearchQuery {
     /// The maximum price for each asset.
     pub max_price: Option<u64>,
     /// The maximum assets Roblox should return per page.
-    /// View [`Limit`] for more information.
-    pub limit: Option<Limit>,
+    /// View [`CatalogQueryLimit`] for more information.
+    pub limit: Option<CatalogQueryLimit>,
     /// Sort between different sale types of assets.
     /// View [`SalesTypeFilter`] for more information.
     pub sales_type_filter: Option<SalesTypeFilter>,
@@ -866,8 +868,10 @@ impl AvatarSearchQueryBuilder {
         self
     }
 
-    #[allow(missing_docs)]
-    pub fn limit(mut self, limit: Limit) -> Self {
+    /// Sets the amount of items to return per page.
+    ///
+    /// Note that this uses [`CatalogQueryLimit`] instead of the universal [`Limit`].
+    pub fn limit(mut self, limit: CatalogQueryLimit) -> Self {
         self.query.limit = Some(limit);
         self
     }

--- a/src/catalog/catalog_types.rs
+++ b/src/catalog/catalog_types.rs
@@ -1,6 +1,8 @@
 use super::request_types;
+
+// Allow unused imports so they can be linked to in the docs.
 #[allow(unused_imports)]
-use crate::{Client, RoboatError};
+use crate::{Client, Limit, RoboatError};
 use serde::{Deserialize, Serialize};
 
 const AVATAR_CATALOG_SEARCH_BASE_URL: &str = "https://catalog.roblox.com/v1/search/items?";

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -3,7 +3,7 @@ use request_types::AvatarSearchQueryResponse;
 
 use catalog_types::QueryLimit;
 
-/// re export all types
+// Re-export all types so that they are easily accessible from the crate root.
 pub use catalog_types::{
     AssetType, AvatarSearchQuery, AvatarSearchQueryBuilder, BundleType, CatalogQueryLimit,
     Category, CreatorType, Genre, Item, ItemDetails, ItemRestriction, ItemStatus, ItemType,

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -7,7 +7,7 @@ use catalog_types::QueryLimit;
 pub use catalog_types::{
     AssetType, AvatarSearchQuery, AvatarSearchQueryBuilder, BundleType, Category, CreatorType,
     Genre, Item, ItemDetails, ItemRestriction, ItemStatus, ItemType, PriceStatus, QueryGenre,
-    SortAggregation, SortType, Subcategory,
+    SortAggregation, SortType, Subcategory, SalesTypeFilter, Limit
 };
 
 /// Types related to the avatar catalog.

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -5,9 +5,9 @@ use catalog_types::QueryLimit;
 
 /// re export all types
 pub use catalog_types::{
-    AssetType, AvatarSearchQuery, AvatarSearchQueryBuilder, BundleType, Category, CreatorType,
-    Genre, Item, ItemDetails, ItemRestriction, ItemStatus, ItemType, PriceStatus, QueryGenre,
-    SortAggregation, SortType, Subcategory, SalesTypeFilter, Limit
+    AssetType, AvatarSearchQuery, AvatarSearchQueryBuilder, BundleType, CatalogQueryLimit,
+    Category, CreatorType, Genre, Item, ItemDetails, ItemRestriction, ItemStatus, ItemType,
+    PriceStatus, QueryGenre, SalesTypeFilter, SortAggregation, SortType, Subcategory,
 };
 
 /// Types related to the avatar catalog.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -257,8 +257,14 @@ const USER_AGENT: &str =
 const CONTENT_TYPE: &str = "application/json;charset=utf-8";
 
 /// The maximum amount of instances to return from an endpoint. Used as a parameter in various methods that call
-/// endpoints. This is an enum instead of an integer as these are the only values that are accepted by Roblox
+/// endpoints.
+///
+/// This is an enum instead of an integer as these are usually the only values that are accepted by Roblox
 /// for the limit parameter.
+///
+/// This is the most common limit used on Roblox endpoints. However, not all endpoints use this limit.
+/// Some alternative limits are as follows:
+/// * [`catalog::CatalogQueryLimit`]
 #[allow(missing_docs)]
 #[derive(
     Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Serialize, Deserialize, Copy,


### PR DESCRIPTION
The minimum/maximum price and limit were visible on the [API documentation](https://create.roblox.com/docs/studio/catalog-api#marketplace-api) but not implemented for some reason.

There are some hidden parameters like [SalesTypeFilter](https://create.roblox.com/docs/reference/engine/enums/SalesTypeFilter). It's possible there are more but I'm not aware of them.